### PR TITLE
 Add patch to export missing public functions in Windows shared lib 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,7 +4,7 @@
 *.diff binary
 meta.yaml text eol=lf
 build.sh text eol=lf
-build.bat text eol=crlf
+bld.bat text eol=crlf
 
 # github helper pieces to make some files not show up in diffs automatically
 .azure-pipelines/* linguist-generated=true

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -25,7 +25,7 @@ set "MICROMAMBA_EXE=%MICROMAMBA_TMPDIR%\micromamba.exe"
 
 echo Downloading micromamba %MICROMAMBA_VERSION%
 if not exist "%MICROMAMBA_TMPDIR%" mkdir "%MICROMAMBA_TMPDIR%"
-certutil -urlcache -split -f "%MICROMAMBA_URL%" "%MICROMAMBA_EXE%"
+powershell -ExecutionPolicy Bypass -Command "(New-Object Net.WebClient).DownloadFile('%MICROMAMBA_URL%', '%MICROMAMBA_EXE%')"
 if !errorlevel! neq 0 exit /b !errorlevel!
 
 echo Creating environment

--- a/recipe/patches/0004-expose-missing-functions-windows-backport-744.patch
+++ b/recipe/patches/0004-expose-missing-functions-windows-backport-744.patch
@@ -1,0 +1,132 @@
+From 4b951f860ff157f9c553618f819269aef1112fb6 Mon Sep 17 00:00:00 2001
+From: Silvio Traversaro <silvio.traversaro@iit.it>
+Date: Mon, 2 Jun 2025 17:36:06 +0200
+Subject: [PATCH] Add missing OSQP_API annotations in osqp_api_functions.h
+
+---
+ include/public/osqp_api_functions.h | 42 ++++++++++++++---------------
+ 1 file changed, 21 insertions(+), 21 deletions(-)
+
+diff --git a/include/public/osqp_api_functions.h b/include/public/osqp_api_functions.h
+index bd159f14..13056819 100644
+--- a/include/public/osqp_api_functions.h
++++ b/include/public/osqp_api_functions.h
+@@ -37,12 +37,12 @@ extern "C" {
+  * @param  p     Vector of column pointers
+  * @return       Pointer to new CSC matrix, or null on error
+  */
+-OSQPCscMatrix* OSQPCscMatrix_new(OSQPInt    m,
+-                                 OSQPInt    n,
+-                                 OSQPInt    nzmax,
+-                                 OSQPFloat* x,
+-                                 OSQPInt*   i,
+-                                 OSQPInt*   p);
++OSQP_API OSQPCscMatrix* OSQPCscMatrix_new(OSQPInt    m,
++                                          OSQPInt    n,
++                                          OSQPInt    nzmax,
++                                          OSQPFloat* x,
++                                          OSQPInt*   i,
++                                          OSQPInt*   p);
+ 
+ /**
+  * Free a CSC matrix object allocated by @ref OSQPCscMatrix_new.
+@@ -55,7 +55,7 @@ OSQPCscMatrix* OSQPCscMatrix_new(OSQPInt    m,
+  *
+  * @param mat Matrix to free
+  */
+-void OSQPCscMatrix_free(OSQPCscMatrix* mat);
++OSQP_API void OSQPCscMatrix_free(OSQPCscMatrix* mat);
+ 
+ /**
+  * Allocates a new Compressed-Column-Sparse (CSC) matrix with zero entries.
+@@ -68,8 +68,8 @@ void OSQPCscMatrix_free(OSQPCscMatrix* mat);
+  * @param  n Number of columns
+  * @return   Pointer to new CSC matrix, or null on error
+  */
+-OSQPCscMatrix* OSQPCscMatrix_zeros(OSQPInt m,
+-                                   OSQPInt n);
++OSQP_API OSQPCscMatrix* OSQPCscMatrix_zeros(OSQPInt m,
++                                            OSQPInt n);
+ 
+ /**
+  * Allocates a new Compressed-Column-Sparse (CSC) identity with 1s on the diagonal.
+@@ -79,7 +79,7 @@ OSQPCscMatrix* OSQPCscMatrix_zeros(OSQPInt m,
+  * @param  m Number of rows/columns
+  * @return   Pointer to new CSC matrix, or null on error
+  */
+-OSQPCscMatrix* OSQPCscMatrix_identity(OSQPInt m);
++OSQP_API OSQPCscMatrix* OSQPCscMatrix_identity(OSQPInt m);
+ 
+ /**
+  * Allocates a new Compressed-Column-Sparse (CSC) diagonal matrix with a given value.
+@@ -94,9 +94,9 @@ OSQPCscMatrix* OSQPCscMatrix_identity(OSQPInt m);
+  * @param  scalar Scalar value to put on the diagonal
+  * @return        Pointer to new CSC matrix, or null on error
+  */
+-OSQPCscMatrix* OSQPCscMatrix_diag_scalar(OSQPInt   m,
+-                                         OSQPInt   n,
+-                                         OSQPFloat scalar);
++OSQP_API OSQPCscMatrix* OSQPCscMatrix_diag_scalar(OSQPInt   m,
++                                                  OSQPInt   n,
++                                                  OSQPFloat scalar);
+ 
+ /**
+  * Allocates a new Compressed-Column-Sparse (CSC) diagonal matrix with given values on the diagonal.
+@@ -111,9 +111,9 @@ OSQPCscMatrix* OSQPCscMatrix_diag_scalar(OSQPInt   m,
+  * @param  vals Values to put on the diagonal - length min(n,m)
+  * @return      Pointer to new CSC matrix, or null on error
+  */
+-OSQPCscMatrix* OSQPCscMatrix_diag_vec(OSQPInt    m,
+-                                      OSQPInt    n,
+-                                      OSQPFloat* vals);
++OSQP_API OSQPCscMatrix* OSQPCscMatrix_diag_vec(OSQPInt    m,
++                                               OSQPInt    n,
++                                               OSQPFloat* vals);
+ 
+ #endif
+ 
+@@ -152,7 +152,7 @@ OSQP_API void OSQPCscMatrix_set_data(OSQPCscMatrix* M,
+  *
+  * @return Pointer to new settings object, or null on error
+  */
+-OSQPSettings* OSQPSettings_new();
++OSQP_API OSQPSettings* OSQPSettings_new();
+ 
+ /**
+  * Free an OSQPSettings object.
+@@ -161,7 +161,7 @@ OSQPSettings* OSQPSettings_new();
+  *
+  * @param settings The settings object to free
+  */
+-void OSQPSettings_free(OSQPSettings* settings);
++OSQP_API void OSQPSettings_free(OSQPSettings* settings);
+ #endif
+ 
+ /** @} */
+@@ -179,7 +179,7 @@ void OSQPSettings_free(OSQPSettings* settings);
+  *
+  * @return Pointer to new codegen defines object, or null on error
+  */
+-OSQPCodegenDefines* OSQPCodegenDefines_new();
++OSQP_API OSQPCodegenDefines* OSQPCodegenDefines_new();
+ 
+ /**
+  * Free an OSQPCodegenDefines object.
+@@ -188,7 +188,7 @@ OSQPCodegenDefines* OSQPCodegenDefines_new();
+  *
+  * @param defs The defines object to free
+  */
+-void OSQPCodegenDefines_free(OSQPCodegenDefines* defs);
++OSQP_API void OSQPCodegenDefines_free(OSQPCodegenDefines* defs);
+ #endif
+ 
+ /** @} */
+@@ -303,7 +303,7 @@ OSQP_API OSQPInt osqp_solve(OSQPSolver* solver);
+  * @param  solution Solution object to store result in
+  * @return          Error flag
+  */
+-OSQPInt osqp_get_solution(OSQPSolver* solver, OSQPSolution* solution);
++OSQP_API OSQPInt osqp_get_solution(OSQPSolver* solver, OSQPSolution* solution);
+ 
+ # ifndef OSQP_EMBEDDED_MODE
+ 

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -16,9 +16,10 @@ source:
       # see: https://github.com/conda-forge/libosqp-feedstock/pull/12#discussion_r1807117589
     - patches/0001-Install-osqp_demo-and-osqp_tester.patch
     - patches/0003-change-path-to-testcodes-dir.patch
+    - patches/0004-expose-missing-functions-windows-backport-744.patch
 
 build:
-  number: 1
+  number: 2
 requirements:
   build:
     - ${{ compiler('c') }}


### PR DESCRIPTION
Backport https://github.com/osqp/osqp/pull/744 .


Without this, builds linking shared builds of OSQP on Windows could fail with errors like:

~~~
compilation_unit_using_osqp.cpp.obj : error LNK2019: unresolved external symbol OSQPCscMatrix_new referenced in function function_using_osqp
compilation_unit_using_osqp.cpp.obj : error LNK2019: unresolved external symbol OSQPCscMatrix_free referenced in function function_using_osqp
~~~

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
